### PR TITLE
Add size control for `movxf`/`movfx`

### DIFF
--- a/machine-tables/instruction-table.csv
+++ b/machine-tables/instruction-table.csv
@@ -30,9 +30,9 @@ opcode,mnemonic,hbits,opcount,extension
 020,movsx,000f,2,X-main
 021,bswap,000f,2,X-main
 022,movsif,000f,2,X-float
-023,movxf,000f,2,X-float
+023,movxf,ssif,2,X-float
 024,movfsi,000f,2,X-float
-025,movfx,000f,2,X-float
+025,movfx,ssif,2,X-float
 026,cvtf,000f,2,X-float
 028,repbi,0000,prefix,X-main
 029,repbc,cccc,prefix,X-main


### PR DESCRIPTION
This adds a size control to specify the portion of the fixed-point value used for integer/fractional bits, in total supporting 7 different sizes (0 fractional bits (integer), 1/8 fractional, 1/4 fractional, 1/2 fractional, 3/4 fractional, 7/8 fractional, and fully fractional).