### PR TITLE
Add vshuffle instruction

### DIFF
--- a/specs/vector.md
+++ b/specs/vector.md
@@ -144,6 +144,7 @@ Exceptions:
 - UND, if any operand constraint is violated
 - PROT, for opcode 0x403, if the BASE or COUNT exceeds the size of the vector element.
 - PROT, for opcode 0x403, if the total number of elements, multiplied by COUNT, is more than 64-bits. 
+- PROT, for opcode 0x403, if any reserved bits are set.
 
 
 Instructions:
@@ -161,4 +162,5 @@ For `vextract`, the selection mask is given as follows:
 | 7-9 | COUNT | The number of bits contiguously selected from each element, starting from BASE, minus 1|
 | 10-11 | ELEMSS | The size control, `log2(size)`, indicating the size of the elements |
 
+All other bits are reserved.
 

--- a/specs/vector.md
+++ b/specs/vector.md
@@ -131,23 +131,34 @@ Exceptions:
 Instructions:
 - 0x401 (vmov): Moves a 16-byte value into the destination vector operand
 
-## Shuffle Vector 
+## Vector Permutations and Bit Selection 
 
-Opcodes: 0x402
+Opcodes: 0x402-0x403
 Operands: 2
-h: [00 ss], where `ss` is the element size.
+h: Opcode 0x402, [00 ss], where `ss` is the element size. Opcode 0x403, `[rrrr]`, where `rrrr` is the general purpose register for the destination operand.
 
-Operand Constraints: No operand may be a memory reference. The first operand must be a vector register, and the second operand must not be a vector register or immediate of size 16
+Operand Constraints: No operand may be a memory reference. The first operand must be a vector register, and the second operand must not be a vector register or immediate of size 16. For opcode 0x403, the second operand must be an immediate,
 
 Exceptions:
 - UND, if `cr0.VEC=0`
 - UND, if any operand constraint is violated
-- PROT, if the permutation given specifies an out-of-range element for the element size and vector size
+- PROT, for opcode 0x403, if the BASE or COUNT exceeds the size of the vector element.
+- PROT, for opcode 0x403, if the total number of elements, multiplied by COUNT, is more than 64-bits. 
+
 
 Instructions:
 - 0x402 (vshuffle): Shuffles the elements of the first operand according to the permutation given in the second operand.
+- 0x403 (vextract): Extract bits from vector elements into general purpose register according to a selection mask given in the second operand
 
-The permutation is made up of 2-8 4-bit location references. The nth 4-bit reference from the Least significant bit refers to the nth element from the least significant element of the destiniation vector. Additional references are ignored. The value in the reference is the element number (from the least significant) in the source vector.
+For `vshuffle`, The permutation is made up of 2-8 4-bit location references. 
+The nth 4-bit reference from the Least significant bit refers to the nth element from the least significant element of the destiniation vector. Additional references are ignored. The value in the reference is the element number (from the least significant) in the source vector. 
+Each location has high order bits masked off according to the total number of elements in the vector.
 
+For `vextract`, the selection mask is given as follows:
+
+| Bits | Name | Description |
+| 0-5  | BASE | The lowest order bit selected from each element by the instruction, from 0-63|
+| 7-9 | COUNT | The number of bits contiguously selected from each element, starting from BASE, minus 1|
+| 10-11 | ELEMSS | The size control, `log2(size)`, indicating the size of the elements |
 
 

--- a/specs/vector.md
+++ b/specs/vector.md
@@ -131,27 +131,23 @@ Exceptions:
 Instructions:
 - 0x401 (vmov): Moves a 16-byte value into the destination vector operand
 
-## Bulk Vector Register Storage
+## Shuffle Vector 
 
-Opcodes: 0x402-0x405
-Operands: Opcodes 0x402 and 0x404, 1. Opcodes 0x403 and 0x405, 0.
-h: Unused and shall be 0
+Opcodes: 0x402
+Operands: 2
+h: [00 ss], where `ss` is the element size.
 
-Operand Constraints: 0x402 and 0x404, the operand shall be an indirect register or a memory reference.
+Operand Constraints: No operand may be a memory reference. The first operand must be a vector register, and the second operand must not be a vector register or immediate of size 16
 
 Exceptions:
 - UND, if `cr0.VEC=0`
 - UND, if any operand constraint is violated
-- PF, if any memory reference is invalid or an out-of-range virtual address
-- PF, if an access violation occurs
-- PF, if a memory reference is an invalid physical address.
+- PROT, if the permutation given specifies an out-of-range element for the element size and vector size
 
-Operations:
-- 0x402 (stovr): Stores each vector register pair in 512 bytes of consecutive storage starting at the memory reference given by the operand
-- 0x403 (pushvr): Pushes each vector register pair in reverse order to the stack.
-- 0x404 (resvr): Restores each vector register pair from the 512 bytes of consecutive storage starting at the memory reference given by the operand.
-- 0x405 (popvr): Pops each vector register pair from the stack.
+Instructions:
+- 0x402 (vshuffle): Shuffles the elements of the first operand according to the permutation given in the second operand.
 
-Each operation is relatively atomic with other memory operations (Note: in particular, `pushvr` and `popvr` only perform one memory operation)
+The permutation is made up of 2-8 4-bit location references. The nth 4-bit reference from the Least significant bit refers to the nth element from the least significant element of the destiniation vector. Additional references are ignored. The value in the reference is the element number (from the least significant) in the source vector.
+
 
 


### PR DESCRIPTION
Fixes #37 

This also removes obselete `stovr` et. al, which were added prior to register size expansion to save the vector register state (which is now saved by `stoar`).