### PR TITLE
Allow use of vector register operands in `cmpxchg`, `xchg`, and `wcmpxchg`

### DIFF
--- a/specs/vector.md
+++ b/specs/vector.md
@@ -55,7 +55,7 @@ Except where stated, vector register operands may only be used by instructions m
 
 The Long Immediate value structure is changed as follows: The structure shall be `[11 m yy r ss zzzz yyyy]`; `ss` may have the value `3` (corresponding to a size of 16).
 
-An `ss` value of 3 may only be used with the `vmov` instruction, may not be pcrelative, and may not be a memory reference. Memory references for a `vmov` instruction use `zzzz` as the extended size control value. Such operands shall have a size of at most `16` (zzzz=4).
+An `ss` value of 3 may only be used with the `vmov`, `cmpxchg`, and `wcmpxchg` instructions, may not be pcrelative, and may not be a memory reference. Memory references for a `vmov`, `xchg`, `cmpxchg`, and `wcmpxchg` instruction use `zzzz` as the extended size control value. Such operands shall have a size of at most `16` (zzzz=4).
 
 
 

--- a/specs/vector.md
+++ b/specs/vector.md
@@ -49,7 +49,7 @@ Vector Register Operands address pairs of vector registers, according to `rrrrrr
 
 `ssss` may be at most `4`, though future extensions may permit values greater than 4.
 
-Except where stated, vector register operands may only be used by instructions modified by the `vec` prefix, or instructions defined by this extension.
+Except where stated, vector register operands may only be used by instructions modified by the `vec` prefix, opcodes 0x200-0x202 (`xchg`, `cmpxchg`, and `wcmpxchg`), or instructions defined by this extension.
 
 ### Long Immediate Values
 


### PR DESCRIPTION
This allows 16-byte wide operands to be used in atomic compare-and-swap and xchg operations when the X-vector extension is available.